### PR TITLE
feat: add wireguard server peer to peer routing

### DIFF
--- a/api/v1alpha1/wireguardpeer_types.go
+++ b/api/v1alpha1/wireguardpeer_types.go
@@ -55,6 +55,10 @@ type WireguardPeerSpec struct {
 	//+kubebuilder:validation:Required
 	//+kubebuilder:validation:MinLength=1
 	WireguardRef string `json:"wireguardRef"`
+	// The key is used as the opposite of AllowedIPs. The wireguard server is using this flag to build its AllowedIPs configuration for the peer.
+	Routes []string `json:"routes,omitempty"`
+	// RoutesV6 specifies IPv6 CIDR ranges that this peer is responsible for routing. Similar to Routes but for IPv6.
+	RoutesV6 []string `json:"routesV6,omitempty"`
 	// Egress network policies for the peer.
 	EgressNetworkPolicies EgressNetworkPolicies `json:"egressNetworkPolicies,omitempty"`
 	DownloadSpeed         Speed                 `json:"downloadSpeed,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -258,6 +258,16 @@ func (in *WireguardPeerList) DeepCopyObject() runtime.Object {
 func (in *WireguardPeerSpec) DeepCopyInto(out *WireguardPeerSpec) {
 	*out = *in
 	in.PrivateKey.DeepCopyInto(&out.PrivateKey)
+	if in.Routes != nil {
+		in, out := &in.Routes, &out.Routes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.RoutesV6 != nil {
+		in, out := &in.RoutesV6, &out.RoutesV6
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EgressNetworkPolicies != nil {
 		in, out := &in.EgressNetworkPolicies, &out.EgressNetworkPolicies
 		*out = make(EgressNetworkPolicies, len(*in))

--- a/config/crd/bases/vpn.wireguard-operator.io_wireguardpeers.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguardpeers.yaml
@@ -143,6 +143,19 @@ spec:
                 description: The key used by the peer to authenticate with the wg
                   server.
                 type: string
+              routes:
+                description: The key is used as the opposite of AllowedIPs. The wireguard
+                  server is using this flag to build its AllowedIPs configuration
+                  for the peer.
+                items:
+                  type: string
+                type: array
+              routesV6:
+                description: RoutesV6 specifies IPv6 CIDR ranges that this peer is
+                  responsible for routing. Similar to Routes but for IPv6.
+                items:
+                  type: string
+                type: array
               uploadSpeed:
                 properties:
                   config:

--- a/config/samples/vpn_v1alpha1_wireguardpeer.yaml
+++ b/config/samples/vpn_v1alpha1_wireguardpeer.yaml
@@ -3,4 +3,8 @@ kind: WireguardPeer
 metadata:
   name: wireguardpeer-sample
 spec:
-  # TODO(user): Add fields here
+  wireguardRef: "wireguard-sample"
+  # Networks that this peer is responsible for routing (e.g., the peer's local LAN)
+  # Other peers can reach these networks through the WireGuard server.
+  # routes:
+  #   - "10.10.30.0/24"

--- a/examples/peer-routing-example.yaml
+++ b/examples/peer-routing-example.yaml
@@ -1,0 +1,38 @@
+# Example: Peer-to-Peer Routing Through WireGuard Server
+#
+# This example demonstrates how to configure peers to route traffic
+# between each other's networks through the WireGuard server.
+#
+# Scenario:
+# - the peer1 has a local network 10.10.30.0/24 that it wants to share
+# - other peers should be able to reach the network peer1 routes.
+# - The WireGuard server (e.g., with CIDR 10.231.234.0/24) routes traffic between them
+
+---
+apiVersion: vpn.wireguard-operator.io/v1alpha1
+kind: WireguardPeer
+metadata:
+  name: peer1-with-local-network
+spec:
+  wireguardRef: "vpn"
+  # peer1 has a local network that it is responsible for routing
+  # This will be added to the peer's AllowedIPs on the server,
+  # and routes will be created on the server to forward traffic
+  # to this network via peer1's WireGuard address.
+  routes:
+    - "10.10.30.0/24"
+
+---
+# How it works:
+# 1. peer1 specifies routes: ["10.10.30.0/24"]
+# 2. The WireGuard server adds 10.10.30.0/24 to peer1's AllowedIPs
+# 3. The agent creates a route: 10.10.30.0/24 via peer1's WireGuard IP
+# 4. When other peers send traffic to 10.10.30.0/24 through the WireGuard server:
+#    a. Traffic arrives at the WireGuard server
+#    b. Server looks up the route and forwards to peer1
+#    c. peer1 routes the traffic to its local network
+#
+# Note: peer1 must have IP forwarding enabled and appropriate
+# routing/NAT configuration to route traffic to its local network.
+
+# Note: The other peers require a route configuration to "10.10.30.0/24".


### PR DESCRIPTION
This pull request enables routing to a peers networks (site to site or point to site connections).

If there is anything I should change to accept the PR, let me know :)