### PR TITLE
Fix peer reconcilication

### DIFF
--- a/internal/controller/wireguard_controller_test.go
+++ b/internal/controller/wireguard_controller_test.go
@@ -1688,4 +1688,123 @@ var _ = Describe("wireguard controller", func() {
 			))
 		})
 	})
+
+	Context("Race condition: WireguardPeer spec completeness", func() {
+		It("should fully initialize all peers (publicKey, privateKeyRef) even when multiple peers are created rapidly", func() {
+			// This test reproduces the race condition between WireguardPeerReconciler
+			// and WireguardReconciler. When a peer is created, the peer controller
+			// must set publicKey/privateKeyRef (via spec update), but the wireguard
+			// controller may also update the same peer's spec (to allocate an address).
+			// If both controllers race on the same ResourceVersion, the peer controller's
+			// key update can be lost, leaving the peer without publicKey/privateKeyRef.
+
+			RaceTimeout := time.Second * 30
+			expectedAddress := "69.0.0.100"
+			var expectedNodePort = "30100"
+
+			Expect(createNode(expectedAddress)).Should(Succeed())
+
+			wgServer := &v1alpha1.Wireguard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      wgKey.Name,
+					Namespace: wgKey.Namespace,
+				},
+				Spec: v1alpha1.WireguardSpec{
+					ServiceType: corev1.ServiceTypeNodePort,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), wgServer)).Should(Succeed())
+
+			// Wait for the service to be created, then set it up so the WG becomes Ready.
+			serviceName := wgKey.Name + "-svc"
+			serviceKey := types.NamespacedName{Namespace: wgKey.Namespace, Name: serviceName}
+
+			Eventually(func() error {
+				svc := &corev1.Service{}
+				return k8sClient.Get(context.Background(), serviceKey, svc)
+			}, Timeout, Interval).Should(Succeed())
+
+			Expect(reconcileServiceWithTypeNodePort(serviceKey, expectedNodePort, 51820)).Should(Succeed())
+
+			// Wait for the Wireguard to become Ready — the peer controller won't
+			// proceed past key generation until the server is ready.
+			Eventually(func() string {
+				wg := &v1alpha1.Wireguard{}
+				_ = k8sClient.Get(context.Background(), wgKey, wg)
+				return wg.Status.Status
+			}, Timeout, Interval).Should(Equal(v1alpha1.Ready))
+
+			// Create multiple peers rapidly to increase the race window.
+			peerCount := 5
+			peerKeys := make([]types.NamespacedName, peerCount)
+			for i := 0; i < peerCount; i++ {
+				peerKeys[i] = types.NamespacedName{
+					Name:      fmt.Sprintf("race-peer-%d", i),
+					Namespace: wgNamespace,
+				}
+				peer := &v1alpha1.WireguardPeer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      peerKeys[i].Name,
+						Namespace: peerKeys[i].Namespace,
+					},
+					Spec: v1alpha1.WireguardPeerSpec{
+						WireguardRef: wgName,
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), peer)).Should(Succeed())
+			}
+
+			// Verify every peer eventually gets fully initialized:
+			// - publicKey must be non-empty
+			// - privateKeyRef.secretKeyRef.name must be non-empty
+			// - address must be allocated
+			// - status must become ready
+			//
+			// If the race condition is present, at least one peer will be stuck
+			// with an empty publicKey and privateKeyRef forever.
+			for i := 0; i < peerCount; i++ {
+				peerKey := peerKeys[i]
+
+				Eventually(func() string {
+					peer := &v1alpha1.WireguardPeer{}
+					err := k8sClient.Get(context.Background(), peerKey, peer)
+					if err != nil {
+						return ""
+					}
+					return peer.Spec.PublicKey
+				}, RaceTimeout, Interval).ShouldNot(BeEmpty(),
+					fmt.Sprintf("peer %s should have publicKey set", peerKey.Name))
+
+				Eventually(func() string {
+					peer := &v1alpha1.WireguardPeer{}
+					err := k8sClient.Get(context.Background(), peerKey, peer)
+					if err != nil {
+						return ""
+					}
+					return peer.Spec.PrivateKey.SecretKeyRef.Name
+				}, RaceTimeout, Interval).ShouldNot(BeEmpty(),
+					fmt.Sprintf("peer %s should have privateKeyRef set", peerKey.Name))
+
+				Eventually(func() string {
+					peer := &v1alpha1.WireguardPeer{}
+					err := k8sClient.Get(context.Background(), peerKey, peer)
+					if err != nil {
+						return ""
+					}
+					return peer.Spec.Address
+				}, RaceTimeout, Interval).ShouldNot(BeEmpty(),
+					fmt.Sprintf("peer %s should have address allocated", peerKey.Name))
+
+				Eventually(func() string {
+					peer := &v1alpha1.WireguardPeer{}
+					err := k8sClient.Get(context.Background(), peerKey, peer)
+					if err != nil {
+						return ""
+					}
+					return peer.Status.Status
+				}, RaceTimeout, Interval).Should(Equal(v1alpha1.Ready),
+					fmt.Sprintf("peer %s should reach ready status", peerKey.Name))
+			}
+		})
+	})
 })

--- a/internal/controller/wireguardpeer_controller.go
+++ b/internal/controller/wireguardpeer_controller.go
@@ -121,21 +121,19 @@ func (r *WireguardPeerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if peer.Spec.PublicKey == "" {
 		secretName := peer.Name + "-peer"
 		existingSecret := &corev1.Secret{}
-		var privateKey, publicKey string
+		var publicKey string
 
 		err = r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: peer.Namespace}, existingSecret)
 		if err == nil {
 			// Secret already exists (previous attempt created it but the spec
 			// update was lost due to a conflict). Reuse the existing keys.
 			log.Info("Secret already exists, reusing existing keys", "secret.Name", secretName)
-			privateKey = string(existingSecret.Data["privateKey"])
 			publicKey = string(existingSecret.Data["publicKey"])
 		} else if errors.IsNotFound(err) {
 			// Secret does not exist yet — generate new keys and create it.
-			privateKey = key.String()
 			publicKey = key.PublicKey().String()
 
-			secret := r.secretForPeer(peer, privateKey, publicKey)
+			secret := r.secretForPeer(peer, key.String(), publicKey)
 			log.Info("Creating a new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
 			if err = r.Create(ctx, secret); err != nil {
 				log.Error(err, "Failed to create new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)

--- a/internal/controller/wireguardpeer_controller.go
+++ b/internal/controller/wireguardpeer_controller.go
@@ -119,25 +119,45 @@ func (r *WireguardPeerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if peer.Spec.PublicKey == "" {
-		privateKey := key.String()
-		publicKey := key.PublicKey().String()
+		secretName := peer.Name + "-peer"
+		existingSecret := &corev1.Secret{}
+		var privateKey, publicKey string
 
-		secret := r.secretForPeer(peer, privateKey, publicKey)
+		err = r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: peer.Namespace}, existingSecret)
+		if err == nil {
+			// Secret already exists (previous attempt created it but the spec
+			// update was lost due to a conflict). Reuse the existing keys.
+			log.Info("Secret already exists, reusing existing keys", "secret.Name", secretName)
+			privateKey = string(existingSecret.Data["privateKey"])
+			publicKey = string(existingSecret.Data["publicKey"])
+		} else if errors.IsNotFound(err) {
+			// Secret does not exist yet — generate new keys and create it.
+			privateKey = key.String()
+			publicKey = key.PublicKey().String()
 
-		log.Info("Creating a new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
-		err = r.Create(ctx, secret)
-		if err != nil {
-			log.Error(err, "Failed to create new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
+			secret := r.secretForPeer(peer, privateKey, publicKey)
+			log.Info("Creating a new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
+			if err = r.Create(ctx, secret); err != nil {
+				log.Error(err, "Failed to create new secret", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
+				return ctrl.Result{}, err
+			}
+		} else {
+			log.Error(err, "Failed to check for existing secret", "secret.Name", secretName)
 			return ctrl.Result{}, err
 		}
 
-		newPeer.Spec.PublicKey = publicKey
-		newPeer.Spec.PrivateKey = v1alpha1.PrivateKey{
-			SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: peer.Name + "-peer"}, Key: "privateKey"}}
-		err = r.Update(ctx, newPeer)
+		// Use a merge patch to set only the key fields. Unlike Update(),
+		// a patch doesn't send the full object and won't conflict with
+		// concurrent updates to other fields (e.g. address allocation by
+		// the Wireguard controller).
+		patchBase := client.MergeFrom(peer.DeepCopy())
+		peer.Spec.PublicKey = publicKey
+		peer.Spec.PrivateKey = v1alpha1.PrivateKey{
+			SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secretName}, Key: "privateKey"}}
+		err = r.Patch(ctx, peer, patchBase)
 
 		if err != nil {
-			log.Error(err, "Failed to create new peer", "secret.Namespace", secret.Namespace, "secret.Name", secret.Name)
+			log.Error(err, "Failed to update peer with keys", "peer.Name", peer.Name)
 			return ctrl.Result{}, err
 		}
 
@@ -192,12 +212,13 @@ func (r *WireguardPeerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if len(newPeer.OwnerReferences) == 0 {
 		log.Info("Waiting for owner reference to be set " + wireguard.Name + " " + newPeer.Name)
+		patchBase := client.MergeFrom(newPeer.DeepCopy())
 		if err := ctrl.SetControllerReference(wireguard, newPeer, r.Scheme); err != nil {
 			log.Error(err, "Failed to set controller reference")
 			return ctrl.Result{}, err
 		}
 
-		if err := r.Update(ctx, newPeer); err != nil {
+		if err := r.Patch(ctx, newPeer, patchBase); err != nil {
 			log.Error(err, "Failed to update peer with controller reference")
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
This addresses a race condition between WireguardPeerReconciler and WireguardReconciler that leaves peers stuck without keys.

WireguardReconciler and WireguardPeerReconciler are both trying to update WireguardPeer .spec concurrently leading to a race condition where an address is assigned, ResourceVersion updated but no wireguardpeer can be further configured as Update() is using a different version. We use patch instead so only the changed fields get updated.

Added a test which confirms the bug.